### PR TITLE
Update fcPlot.R

### DIFF
--- a/R/fcPlot.R
+++ b/R/fcPlot.R
@@ -200,7 +200,8 @@ fcPlot <- function(object,
                  color = ~col, colors = colours,
                  marker = list(size = 8, 
                                line = list(width = 0.75, color = 'white')),
-                 text = rownames(plotData), hoverinfo = 'text') %>%
+                 text = rownames(plotData), hoverinfo = 'text',
+                 key = rownames(plotData), ...) %>%
       layout(annotations = annot,
              xaxis = list(title = paste0("log<sub>2</sub>Fold change ",
                                      x1Values[2], " vs ", x1Values[1],


### PR DESCRIPTION
adding key = rownames(plotData) in the plotly plot to allow the updateSelectizeInput shiny funciton to get the name of the selected dot.  (By using text = rownames(plotData) you only allow the gene name to be shown in the hover info, it won't update the key field. The key field can be used by updateSelectizeInput to trigger other events, like showing the related paired plot)