### PR TITLE
removing/updating old URLs and link for glmmTMB()]

### DIFF
--- a/R/glmmRefit.R
+++ b/R/glmmRefit.R
@@ -15,7 +15,7 @@
 #' @param control Optional control parameters, see [lme4::lmerControl()] or
 #'   [lme4::glmerControl()]
 #' @param family Optional GLM family when refitting GLMM using [lme4::glmer()]
-#'   or [glmmTMB()]
+#'   or [`glmmTMB()`]
 #' @param ... Optional arguments passed to either [lme4::glmer()] or
 #'   [lme4::lmer()]
 #' @return Fitted model of class `lmerMod` in the case of LMM, or `glmerMod` or

--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
 [![Lifecycle: Maturing](https://img.shields.io/badge/lifecycle-stable-blue.svg)](https://lifecycle.r-lib.org/articles/stages.html)
 [![License: MIT](https://img.shields.io/badge/License-MIT-mediumpurple.svg)](https://choosealicense.com/licenses/mit/)
 [![CRAN status](https://www.r-pkg.org/badges/version/glmmSeq)](https://cran.r-project.org/package=glmmSeq)
-[![Hits](https://hits.seeyoufarm.com/api/count/incr/badge.svg?url=https%3A%2F%2Fgithub.com%2Fmyles-lewis%2FglmmSeq&count_bg=%2379C83D&title_bg=%23555555&icon=&icon_color=%23E7E7E7&title=hits&edge_flat=false)](https://hits.seeyoufarm.com)
 [![GitHub issues](https://img.shields.io/github/issues/myles-lewis/glmmSeq.svg)](https://GitHub.com/myles-lewis/glmmSeq/issues/)
 [![GitHub
 tag](https://img.shields.io/github/tag/myles-lewis/glmmSeq.svg)](https://GitHub.com/myles-lewis/glmmSeq/tags/)
 [![Downloads](https://cranlogs.r-pkg.org/badges/grand-total/glmmSeq?color=orange)](https://CRAN.R-project.org/package=glmmSeq)
-[![Travis](https://img.shields.io/travis/myles-lewis/glmmSeq.svg)](https://github.com/myles-lewis/glmmSeq)
 
 # glmmSeq 
 
@@ -72,7 +70,7 @@ For examples see the [vignette](https://myles-lewis.github.io/glmmSeq/articles/g
 
 # Reference
 
-glmmSeq was developed by the bioinformatics team at the [Experimental Medicine & Rheumatology department](https://www.qmul.ac.uk/whri/emr/) and [Centre for Translational Bioinformatics](https://www.qmul.ac.uk/c4tb/) at Queen Mary University London.
+glmmSeq was developed by the bioinformatics team at the [Experimental Medicine & Rheumatology department](https://www.qmul.ac.uk/whri/emr/) at Queen Mary University London.
 
 If you use this package please cite as:
 

--- a/vignettes/glmmSeq.rmd
+++ b/vignettes/glmmSeq.rmd
@@ -607,7 +607,7 @@ debugging unforeseeen problems in the core loop.
 
 # Citing glmmSeq
 
-glmmSeq was developed by the bioinformatics team at the [Experimental Medicine & Rheumatology department](https://www.qmul.ac.uk/whri/emr/) and [Centre for Translational Bioinformatics](https://www.qmul.ac.uk/c4tb/) at Queen Mary University London.
+glmmSeq was developed by the bioinformatics team at the [Experimental Medicine & Rheumatology department](https://www.qmul.ac.uk/whri/emr/) at Queen Mary University London.
 
 If you use this package please cite as:
 
@@ -623,7 +623,7 @@ Statistical software used in this package:
 
 2. [lme4](https://dx.doi.org/10.18637/jss.v067.i01): Douglas Bates, Martin Maechler, Ben Bolker, Steve Walker (2015). Fitting Linear Mixed-Effects Models Using lme4. Journal of Statistical Software, 67(1), 1-48. doi: 10.18637/jss.v067.i01.
 
-3. [car](https://socialsciences.mcmaster.ca/jfox/Books/Companion/): John Fox and Sanford Weisberg (2019). An {R} Companion to Applied Regression, Third Edition. Thousand Oaks CA: Sage. URL: https://socialsciences.mcmaster.ca/jfox/Books/Companion/
+3. [car](https://www.john-fox.ca/Companion/): John Fox and Sanford Weisberg (2019). An {R} Companion to Applied Regression, Third Edition. Thousand Oaks CA: Sage. URL: https://www.john-fox.ca/Companion/
   
 4. [MASS](https://www.stats.ox.ac.uk/pub/MASS4/VR4stat.pdf): Venables, W. N. & Ripley, B. D. (2002) Modern Applied Statistics with S. Fourth Edition. Springer, New York. ISBN 0-387-95457-0
 


### PR DESCRIPTION
Removal or update of old URLs, plus fix of the below note. 

  Found the following Rd file(s) with Rd \link{} targets missing package
  anchors:
    glmmRefit.Rd: glmmTMB